### PR TITLE
fix(DiscordRPC): Check string exists before sanitization

### DIFF
--- a/src/DiscordRPC.ts
+++ b/src/DiscordRPC.ts
@@ -32,10 +32,14 @@ export class DiscordRPC {
   private sanitizeActivity(rpcActivity: Presence): Presence {
     return {
       ...rpcActivity,
-      details: rpcActivity.details.substr(0, DiscordRPC.maxStateLength),
-      state: rpcActivity.state.substr(0, DiscordRPC.maxStateLength),
-      smallImageText: rpcActivity.smallImageText.substr(0, DiscordRPC.maxStateLength),
-      largeImageText: rpcActivity.largeImageText.substr(0, DiscordRPC.maxStateLength)
+      details: rpcActivity.details ? rpcActivity.details.substr(0, DiscordRPC.maxStateLength) : "  ",
+      state: rpcActivity.state ? rpcActivity.state.substr(0, DiscordRPC.maxStateLength) : "  ",
+      smallImageText: rpcActivity.smallImageText
+        ? rpcActivity.smallImageText.substr(0, DiscordRPC.maxStateLength)
+        : "  ",
+      largeImageText: rpcActivity.largeImageText
+        ? rpcActivity.largeImageText.substr(0, DiscordRPC.maxStateLength)
+        : "  "
     };
   }
 


### PR DESCRIPTION
I did not check if the strings existed, everything blew up.
fix #59 