### PR TITLE
Rework status text selection

### DIFF
--- a/src/Client.ts
+++ b/src/Client.ts
@@ -32,6 +32,7 @@ interface DestinyCharacterActivitiesComponentResponse {
 }
 
 const PLACE_ORBIT = 2961497387;
+const ACTIVITY_TYPE_FORGE = 838603889;
 
 export class Client {
   public static System: System = DefaultSystem;
@@ -149,7 +150,7 @@ export class Client {
     currentActivityData: DestinyCharacterActivitiesComponent,
     currentCharacterData: DestinyCharacterComponent
   ): Presence {
-    const currentActivity = this.database.getFromDatabase<DestinyActivityDefinition>(
+    let currentActivity = this.database.getFromDatabase<DestinyActivityDefinition>(
       "DestinyActivityDefinition",
       currentActivityData.currentActivityHash
     );
@@ -178,6 +179,14 @@ export class Client {
       "DestinyClassDefinition",
       currentCharacterData.classHash
     );
+
+    if (currentActivity.activityTypeHash == ACTIVITY_TYPE_FORGE) {
+      /*
+       * Forge activity defintions are for some reason rather sparse, but the
+       * playlist activity definition has more detail.
+       */
+      currentActivity = currentPlaylist;
+    }
 
     let detailText;
     if (


### PR DESCRIPTION
Choose more generally-useful text for the status message for different activity types.

Showing the activity-mode description rather than the actual activity name in the text seemed to me to be rather less useful (despite the name, the "description" is often not particularly descriptive). This change shows the activity name directly in the status, while the activity description is hidden behind the mouseover for the curious.

It also pulls out the `currentActivityMode` rather than using the one from the manifest, so it shows the correct crucible modes (instead of always saying "Rumble"). It also pulls out the playlist name, if it's something different, for additional info, eg "Quickplay - Control" or "Private Match - Clash".

The only real oddity I've found is that normal-mode Menagerie gets classed as a "strike", but that seems relatively minor.

I did a runthrough of all the different activity types I could think of, to see what strings are available to pull from, and how this code ends up displaying them. Ended up not pulling from some of the fancier options, but kept them in the sheet for future reference.
[activities.csv](https://github.com/brakacai/discord-ghost/files/3364443/activities.csv.txt)